### PR TITLE
Settings: Run coala on style guides

### DIFF
--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -14,6 +14,7 @@
 import logging
 import sys
 
+from coalib.coala_modes import mode_generate_config
 from pyprint.ConsolePrinter import ConsolePrinter
 
 from dependency_management.requirements.PipRequirement import PipRequirement
@@ -117,6 +118,9 @@ def main(debug=False):
 
     if args.non_interactive:
         return mode_non_interactive(console_printer, args, debug=debug)
+
+    if args.generate_config:
+        return mode_generate_config(args)
 
     return mode_normal(console_printer, None, args, debug=debug)
 

--- a/coalib/coala_modes.py
+++ b/coalib/coala_modes.py
@@ -1,3 +1,6 @@
+from coalib.settings.ConfigGenerator import ConfigGenerator
+
+
 def mode_normal(console_printer, log_printer, args, debug=False):
     """
     This is the default coala mode. User interaction is allowed in this mode.
@@ -99,3 +102,12 @@ def mode_format(args, debug=False):
     _, exitcode, _ = run_coala(
             print_results=print_results_formatted, args=args, debug=debug)
     return exitcode
+
+
+def mode_generate_config(args):
+    """
+    The mode that allows to generate config files based on style guides.
+
+    :param args: Defines languages, style-guides among others
+    """
+    ConfigGenerator(args).create_coafile()

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -155,6 +155,12 @@ To run coala without user interaction, run the `coala --non-interactive`,
         '--no-autoapply-warn', const=True, action='store_const',
         help='turn off warning about patches not being auto applicable')
 
+    config_group.add_argument('-g',
+                              '--generate-config', nargs='+',
+                              metavar='FILE',
+                              help='A tool to generate config files '
+                                   'based on style guide')
+
     inputs_group = arg_parser.add_argument_group('Inputs')
 
     bears = inputs_group.add_argument(

--- a/coalib/settings/ConfigGenerator.py
+++ b/coalib/settings/ConfigGenerator.py
@@ -1,0 +1,146 @@
+import os
+import sys
+import logging
+
+import requests
+from genericpath import exists
+from appdirs import user_data_dir
+
+from coalib.misc import Constants
+from coalib.output.ConfWriter import ConfWriter
+from coalib.settings.ConfigurationGathering import load_configuration
+from coalib.settings.Setting import Setting
+
+
+class ConfigGenerator:
+    """
+    This class generates a .coafile
+    """
+
+    def __init__(self, args):
+        self.args = args
+        self.collector_file = Constants.local_coafile
+        self.base_url = ('https://raw.githubusercontent.com/PrajwalM2212/'
+                         'coala-styles/master/coala_styles/styles/')
+
+    def download_cached_file(self, url, filename):
+        """
+        Download the config file or return the existing config
+        file if it already exists.
+
+        :param url: The url to download from
+        :param filename: The filename in which the config will be saved
+        :return: Return filename
+        """
+        filename = os.path.join(self.data_dir, filename)
+        if exists(filename):
+            return filename
+
+        response = requests.get(url, stream=True, timeout=20)
+        response.raise_for_status()
+
+        with open(filename, 'ab') as file:
+            for chunk in response.iter_content(125):
+                file.write(chunk)
+        return filename
+
+    @property
+    def data_dir(self):
+        """
+        Define the path where downloaded config files will be stored.
+
+        :return: data_dir path
+        """
+        data_dir = os.path.abspath(os.path.join(
+            user_data_dir('coala-styles')))
+
+        os.makedirs(data_dir, exist_ok=True)
+        return data_dir
+
+    def save_sections(self, sections):
+        """
+        Saves the given sections if they are to be saved.
+
+        :param sections: A section dict.
+        """
+
+        conf_writer = ConfWriter(Constants.local_coafile)
+        conf_writer.write_sections(sections)
+        conf_writer.close()
+
+    def create_coafile(self):
+        """
+        Generate .coafile based on user preferences.
+
+        Downloads the config files if they don't already
+        exist. Combines the style-based config files
+        and writes them into .coafile.
+        """
+        config_groups = self.args.generate_config
+        file_list = []
+        lint_files_dict = {}
+
+        for config_group in config_groups:
+            config_group_args = config_group.split(':')
+            try:
+                files = '**'
+                excludes = ''
+                num_args = len(config_group_args)
+                if num_args == 2:
+                    lang, author = config_group_args
+                    lint_files_dict[lang] = (files, excludes)
+                elif num_args == 3:
+                    lang, author, files = config_group_args
+                    lint_files_dict[lang] = (files, excludes)
+                else:
+                    lang, author, files, excludes = config_group_args
+                    lint_files_dict[lang] = (files, excludes)
+            except ValueError:
+                logging.error('Supply command line args in '
+                              'the form language:style_name:files:excludes ')
+                sys.exit(255)
+
+            try:
+                file_name = (self.download_cached_file(
+                    (self.base_url + '{}/{}_config.coafile')
+                    .format(lang, author),
+                    lang + '_' + author))
+
+                file_list.append(file_name)
+
+            except requests.exceptions.HTTPError:
+                logging.warning('{} style guide for {} not avilable'.format(
+                    author, lang
+                ))
+
+        with open(self.collector_file, 'a') as outfile:
+            for fname in file_list:
+                with open(fname) as infile:
+                    for line in infile:
+                        outfile.write(line)
+
+        self.args.save = True
+        self.args.config = self.collector_file
+
+        sections, targets = load_configuration(None, None,
+                                               args=self.args)
+
+        sections.get('cli').delete_setting('config')
+        sections.get('cli').delete_setting('generate_config')
+
+        sections['cli'].name = 'all'
+        sections['all'] = sections['cli']
+        del sections['cli']
+
+        for lang, (files, excludes) in lint_files_dict.items():
+            if sections.get(lang, None):
+                sections.get(lang).append(Setting('files', files))
+                sections.get(lang).append(Setting('ignore', excludes))
+                sections[lang].name = 'all.{}'.format(lang)
+                sections['all.{}'.format(lang)] = sections[lang]
+                del sections[lang]
+
+        for name, section in sections.items():
+            section.append(Setting('comment1', '', ))
+
+        self.save_sections(sections)

--- a/tests/settings/ConfigGeneratorTest.py
+++ b/tests/settings/ConfigGeneratorTest.py
@@ -1,0 +1,146 @@
+import unittest
+import tempfile
+import os
+import logging
+from argparse import Namespace
+
+from coala_utils.string_processing import escape
+from coalib import coala
+from coalib.misc import Constants
+from coalib.settings.ConfigGenerator import ConfigGenerator
+from tests.TestUtilities import execute_coala
+
+
+class ConfigGeneratorTest(unittest.TestCase):
+    def setUp(self):
+        self.config_file = os.path.join(tempfile.gettempdir(), 'temp_file')
+        if os.path.sep == '\\':
+            self.config_file = escape(self.config_file, '\\')
+        self.real_local_coafile = Constants.local_coafile
+        Constants.local_coafile = self.config_file
+        self.args = Namespace()
+        self.uut = ConfigGenerator(self.args)
+
+    def test_creation_with_lang_author(self):
+        self.args.generate_config = ['python:pep8', 'cpp:google']
+
+        self.uut.create_coafile()
+
+        with open(self.config_file) as f:
+            config_contents = f.read()
+
+        self.assertIn(('[all]\n'
+                       '\n'), config_contents)
+
+        self.assertIn(('[all.python]\n'
+                       'bears = PEP8Bear, PycodestyleBear\n'
+                       'language = Python\n'
+                       'files = **\n'
+                       'ignore = \n'
+                       '\n'), config_contents)
+
+        self.assertIn(('[all.cpp]\n'
+                       'bears = CPPLintBear\n'
+                       'language = CPP\n'
+                       'files = **\n'
+                       'ignore = \n'
+                       '\n'), config_contents)
+
+    def test_creation_with_lang_auth_file(self):
+        self.args.generate_config = ['java:sun:a.java,b.java',
+                                     'cpp:apache:c.cpp']
+        self.uut.create_coafile()
+
+        with open(self.config_file) as f:
+            config_contents = f.read()
+
+        test_file = (
+            '[all]\n'
+            '\n'
+            '[all.java]\n'
+            'language = Java\n'
+            'bears = CheckstyleBear\n'
+            'checkstyle_configs = sun\n'
+            'files = a.java,b.java\n'
+            'ignore = \n'
+            '\n'
+        )
+
+        self.assertEqual(test_file, config_contents)
+
+    def test_with_files_args(self):
+        self.args.generate_config = ['java:sun:a.java,b.java']
+        self.args.files = ['a', 'b', 'c']
+
+        self.uut.create_coafile()
+
+        with open(self.config_file) as f:
+            config_contents = f.read()
+
+        test_file = (
+            '[all]\n'
+            'files = a,b,c\n'
+            '\n'
+            '[all.java]\n'
+            'language = Java\n'
+            'bears = CheckstyleBear\n'
+            'checkstyle_configs = sun\n'
+            'files = a.java,b.java\n'
+            'ignore = \n'
+            '\n'
+        )
+
+        self.assertEqual(test_file, config_contents)
+
+    def test_with_files_and_excludes(self):
+        self.args.generate_config = ['java:sun:**:b.java']
+        self.uut.create_coafile()
+
+        with open(self.config_file) as f:
+            config_contents = f.read()
+
+        test_file = (
+            '[all]\n'
+            '\n'
+            '[all.java]\n'
+            'language = Java\n'
+            'bears = CheckstyleBear\n'
+            'checkstyle_configs = sun\n'
+            'files = **\n'
+            'ignore = b.java\n'
+            '\n'
+        )
+
+        self.assertEqual(test_file, config_contents)
+
+    def test_creation_problems(self):
+        with self.assertRaises(SystemExit):
+            self.args.generate_config = ['java']
+            self.uut.create_coafile()
+
+        with self.assertLogs(logging.getLogger(), 'WARNING'):
+            self.args.generate_config = ['java:apache']
+            self.uut.create_coafile()
+
+    def test_execute_coala(self):
+        execute_coala(coala.main, 'coala', '-g', 'python:pep8')
+
+        with open(self.config_file) as f:
+            config_content = f.read()
+
+        self.assertEqual(
+            config_content,
+            '[all]\n'
+            '\n'
+            '[all.python]\n'
+            'bears = PEP8Bear, PycodestyleBear\n'
+            'language = Python\n'
+            'files = **\n'
+            'ignore = \n'
+            '\n'
+        )
+
+    def tearDown(self):
+        Constants.local_coafile = self.real_local_coafile
+        if os.path.exists(self.config_file):
+            os.remove(self.config_file)


### PR DESCRIPTION
This PR allows users to run coala without writing
any configuration files. The user can specify the
style-guide they want to run coala on. Currently
handful of styleguides for java, python, html
and cpp are supported.

Closes https://github.com/coala/coala/issues/4609

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
